### PR TITLE
Moved css regarding flex box from parent element to main content

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,4 +1,8 @@
 .App {
+  text-align: center;
+}
+
+.Content {
   display: flex;
   flex-direction: column;
   text-align: center;


### PR DESCRIPTION
Due to moving div parent element with the class "App", the number input field wasn't centered anymore, since now it is inside another child element.

What I did:
Moved all styling regarding flex box from parent element "App" to child element "Content".