### PR TITLE
Feat/sudoku validation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -5,6 +5,5 @@
 .Content {
   display: flex;
   flex-direction: column;
-  text-align: center;
-  justify-content: center;
+  align-items: center;
 }

--- a/src/components/NumberInput.css
+++ b/src/components/NumberInput.css
@@ -1,5 +1,4 @@
 .NumbInputField {
-  align-self: center;
   display: grid;
   grid-template-columns: repeat(5, 1fr);
 

--- a/src/pages/SudokuPage.css
+++ b/src/pages/SudokuPage.css
@@ -1,0 +1,3 @@
+.SubmitBtn {
+  margin-top: 1.5rem;
+}

--- a/src/pages/SudokuPage.js
+++ b/src/pages/SudokuPage.js
@@ -1,3 +1,4 @@
+import "./SudokuPage.css";
 import Cell from "../components/Cell.js";
 import NumberInput from "../components/NumberInput";
 import { useEffect, useState } from "react";

--- a/src/pages/SudokuPage.js
+++ b/src/pages/SudokuPage.js
@@ -6,6 +6,7 @@ import { v4 as uuidv4 } from "uuid";
 export default function SudokuPage() {
   const [numbers, setNumbers] = useState([[], [], [], [], [], [], [], [], []]);
   const [isLoading, setIsLoading] = useState(false);
+  const [sudokuStatus, setSudokuStatus] = useState("unsolved");
   let selectedCell = [];
 
   useEffect(() => {
@@ -67,6 +68,35 @@ export default function SudokuPage() {
     }
   }
 
+  function handleSubmitClick() {
+    const encodeBoard = (board) =>
+      board.reduce(
+        (result, row, i) =>
+          result +
+          `%5B${encodeURIComponent(row)}%5D${
+            i === board.length - 1 ? "" : "%2C"
+          }`,
+        ""
+      );
+
+    const encodeParams = (params) =>
+      Object.keys(params)
+        .map((key) => key + "=" + `%5B${encodeBoard(params[key])}%5D`)
+        .join("&");
+    const data = {
+      board: numbers,
+    };
+
+    fetch("https://sugoku.herokuapp.com/validate", {
+      method: "POST",
+      body: encodeParams(data),
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    })
+      .then((response) => response.json())
+      .then((response) => setSudokuStatus(response.status))
+      .catch(console.warn);
+  }
+
   return (
     <>
       <div className="Sudoku__grid">
@@ -81,6 +111,10 @@ export default function SudokuPage() {
         <div className="Sudoku__row">{renderCellRow(8)}</div>
       </div>
       <div className="NumbInputField">{renderNumberBtns()}</div>
+      <button className="SubmitBtn" onClick={handleSubmitClick}>
+        Submit
+      </button>
+      <p>{sudokuStatus}</p>
     </>
   );
 }


### PR DESCRIPTION
Just added a simple submit button.
Now you can validate the Sudoku and for now see the status of it. (This will be changed in the future)

What I did:
- Add simple button
- Add logic to fetch (POST) status of validation
(The author of the API I am using documented an example on how to do that, since you have to use application/x-www-form-urlencoded as the content type. I simply copied it and changed the variables.)