### PR TITLE
Style/sudoku page and grid

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -14,3 +14,9 @@
   flex-direction: column;
   align-items: center;
 }
+
+@media screen and (max-width: 320px) {
+  .App__gridLayout {
+    float: left;
+  }
+}

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -2,7 +2,7 @@
   justify-self: center;
   display: flex;
   flex-direction: column;
-  margin-top: 0.5rem;
+  margin: 0.5rem 0 1.5rem 0;
   width: 95vw;
   min-width: 300px;
   color: white;

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -1,0 +1,37 @@
+.Header {
+  justify-self: center;
+  display: flex;
+  flex-direction: column;
+  margin-top: 0.5rem;
+  width: 95vw;
+  min-width: 300px;
+  color: white;
+}
+
+.Header__topImage {
+  height: 65px;
+
+  background: linear-gradient(300.63deg, #412027 45.56%, #562736 85.31%);
+  border: 2px solid #000000;
+  box-sizing: border-box;
+  border-radius: 30px;
+}
+
+.Header__title,
+.Header__subTitle {
+  line-height: 1;
+}
+
+.Header__NavBar {
+  display: none;
+  align-self: flex-end;
+  margin-right: 2rem;
+}
+
+.Header__NavBar > * {
+  margin: 0 5px;
+}
+
+.Header__NavBar--active {
+  display: unset;
+}

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,0 +1,27 @@
+import "./Header.css";
+import { NavLink } from "react-router-dom";
+import { ReactComponent as ProfileIcon } from "../svg/profile-fill.svg";
+import { ReactComponent as HighscoreIcon } from "../svg/chart-fill.svg";
+import { ReactComponent as OptionsIcon } from "../svg/gear-fill.svg";
+
+export default function Header({ title, subTitle, type }) {
+  return (
+    <header className="Header">
+      <div className="Header__topImage">
+        <h1 className="Header__title">{title}</h1>
+        <h2 className="Header__subTitle">{subTitle}</h2>
+      </div>
+      <nav
+        className={`Header__NavBar ${type === "1" && "Header__NavBar--active"}`}
+      >
+        <NavLink to="/profile">
+          <ProfileIcon />
+        </NavLink>
+        <NavLink to="/highscores">
+          <HighscoreIcon />
+        </NavLink>
+        <OptionsIcon />
+      </nav>
+    </header>
+  );
+}

--- a/src/components/NumberInput.css
+++ b/src/components/NumberInput.css
@@ -7,6 +7,7 @@
 
   width: 95vw;
   max-width: 360px;
+  min-width: 300px;
   height: 100px;
 
   background: linear-gradient(300.63deg, #412027 45.56%, #562736 85.31%);

--- a/src/components/SudokuGrid/Cell.js
+++ b/src/components/SudokuGrid/Cell.js
@@ -1,10 +1,22 @@
-export default function Cell({ value, onCellClick, id, isEditable }) {
+export default function Cell({
+  value,
+  onCellClick,
+  id,
+  isEditable,
+  isSelected,
+}) {
   function handleClick() {
     onCellClick(id);
   }
 
   return (
-    <button onClick={handleClick} disabled={isEditable ? false : true}>
+    <button
+      className={`Cell ${isEditable ? "" : "Cell--locked"} ${
+        isSelected ? "Cell--active" : ""
+      } ${`CellRow${id[0]}`} ${`CellColumn${id[1]}`}`}
+      onClick={handleClick}
+      disabled={isEditable ? false : true}
+    >
       {value}
     </button>
   );

--- a/src/components/SudokuGrid/Cell.js
+++ b/src/components/SudokuGrid/Cell.js
@@ -1,3 +1,5 @@
+import getCellClassNames from "../../utility/getCellClassNames.js";
+
 export default function Cell({
   value,
   onCellClick,
@@ -11,9 +13,7 @@ export default function Cell({
 
   return (
     <button
-      className={`Cell ${isEditable ? "" : "Cell--locked"} ${
-        isSelected ? "Cell--active" : ""
-      } ${`CellRow${id[0]}`} ${`CellColumn${id[1]}`}`}
+      className={getCellClassNames(isEditable, isSelected, id)}
       onClick={handleClick}
       disabled={isEditable ? false : true}
     >

--- a/src/components/SudokuGrid/Row.js
+++ b/src/components/SudokuGrid/Row.js
@@ -1,4 +1,5 @@
 import Cell from "./Cell";
+import isCellSelected from "../../utility/isCellSelected";
 
 export default function Row({
   rowData,
@@ -11,18 +12,14 @@ export default function Row({
     <div className="Row">
       {rowData.map((cell, columnNumber) => {
         const isEditable = rowMask[columnNumber] === 0;
-        const isSelected =
-          activeCellID.length === 2 &&
-          rowNumber === activeCellID[0] &&
-          columnNumber === activeCellID[1];
         return (
           <Cell
             key={`${rowNumber}-${columnNumber}`}
-            value={cell === 0 ? "" : cell}
+            value={cell !== 0 && cell}
             id={[rowNumber, columnNumber]}
             isEditable={isEditable}
             onCellClick={onCellInRowClick}
-            isSelected={isSelected}
+            isSelected={isCellSelected(activeCellID, rowNumber, columnNumber)}
           />
         );
       })}

--- a/src/components/SudokuGrid/Row.js
+++ b/src/components/SudokuGrid/Row.js
@@ -1,10 +1,20 @@
 import Cell from "./Cell";
 
-export default function Row({ rowData, rowNumber, rowMask, onCellInRowClick }) {
+export default function Row({
+  rowData,
+  rowNumber,
+  rowMask,
+  onCellInRowClick,
+  activeCellID,
+}) {
   return (
     <div className="Row">
       {rowData.map((cell, columnNumber) => {
         const isEditable = rowMask[columnNumber] === 0;
+        const isSelected =
+          activeCellID.length === 2 &&
+          rowNumber === activeCellID[0] &&
+          columnNumber === activeCellID[1];
         return (
           <Cell
             key={`${rowNumber}-${columnNumber}`}
@@ -12,6 +22,7 @@ export default function Row({ rowData, rowNumber, rowMask, onCellInRowClick }) {
             id={[rowNumber, columnNumber]}
             isEditable={isEditable}
             onCellClick={onCellInRowClick}
+            isSelected={isSelected}
           />
         );
       })}

--- a/src/components/SudokuGrid/Row.js
+++ b/src/components/SudokuGrid/Row.js
@@ -18,7 +18,7 @@ export default function Row({
         return (
           <Cell
             key={`${rowNumber}-${columnNumber}`}
-            value={cell}
+            value={cell === 0 ? "" : cell}
             id={[rowNumber, columnNumber]}
             isEditable={isEditable}
             onCellClick={onCellInRowClick}

--- a/src/components/SudokuGrid/SudokuGrid.css
+++ b/src/components/SudokuGrid/SudokuGrid.css
@@ -1,0 +1,68 @@
+.SudokuGrid {
+  border: 10px solid #4f2531;
+  border-radius: 10px;
+}
+
+.Row {
+  display: flex;
+  width: 90vw;
+  max-width: 360px;
+  min-width: 300px;
+}
+
+.Cell {
+  background: white;
+  color: #344861;
+  border: 1px solid lightsteelblue;
+  aspect-ratio: 1;
+  width: 40px;
+  font-size: 1.8em;
+}
+
+.Cell--locked {
+  background: lightgray;
+}
+.Cell--active {
+  background: slategrey;
+}
+
+.CellRow0 {
+  border-top: none;
+}
+
+.CellRow2 {
+  border-bottom: 2px solid #344861;
+}
+.CellRow3 {
+  border-top: 2px solid #344861;
+}
+
+.CellRow5 {
+  border-bottom: 2px solid #344861;
+}
+.CellRow6 {
+  border-top: 2px solid #344861;
+}
+
+.CellRow8 {
+  border-bottom: none;
+}
+
+.CellColumn0 {
+  border-left: none;
+}
+.CellColumn2 {
+  border-right: 2px solid #344861;
+}
+.CellColumn3 {
+  border-left: 2px solid #344861;
+}
+.CellColumn5 {
+  border-right: 2px solid #344861;
+}
+.CellColumn6 {
+  border-left: 2px solid #344861;
+}
+.CellColumn8 {
+  border-right: none;
+}

--- a/src/components/SudokuGrid/SudokuGrid.js
+++ b/src/components/SudokuGrid/SudokuGrid.js
@@ -1,3 +1,4 @@
+import "./SudokuGrid.css";
 import Row from "./Row.js";
 
 export default function SudokuGrid({

--- a/src/components/SudokuGrid/SudokuGrid.js
+++ b/src/components/SudokuGrid/SudokuGrid.js
@@ -4,6 +4,7 @@ export default function SudokuGrid({
   initialSudoku,
   currentSudoku,
   onCellClick,
+  activeCellID,
 }) {
   return (
     <div className="SudokuGrid">
@@ -14,6 +15,7 @@ export default function SudokuGrid({
           onCellInRowClick={onCellClick}
           rowData={row}
           rowNumber={rowNumber}
+          activeCellID={activeCellID}
         />
       ))}
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,13 +1,21 @@
-body {
+*,
+*::before,
+*::after {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
+    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background: #42454a;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }

--- a/src/pages/MainPage.css
+++ b/src/pages/MainPage.css
@@ -1,39 +1,6 @@
-.Header {
-  align-self: center;
-  display: flex;
-  flex-direction: column;
-  margin-top: 0.5rem;
-  width: 95vw;
-  min-width: 300px;
-  color: white;
-}
-
-.Header__topImage {
-  height: 65px;
-
-  background: linear-gradient(300.63deg, #412027 45.56%, #562736 85.31%);
-  border: 2px solid #000000;
-  box-sizing: border-box;
-  border-radius: 30px;
-}
-
-.Header__title,
-.Header__subTitle {
-  line-height: 1;
-}
-
-.Header__navBar {
-  align-self: flex-end;
-  margin-right: 2rem;
-}
-
-.Header__navBar > * {
-  margin: 0 5px;
-}
-
 .Footer {
   display: flex;
-  justify-content: center;
+  justify-content: space-around;
   height: 100%;
 }
 

--- a/src/pages/MainPage.css
+++ b/src/pages/MainPage.css
@@ -1,4 +1,5 @@
 .Header {
+  align-self: center;
   display: flex;
   flex-direction: column;
   margin-top: 0.5rem;
@@ -31,6 +32,8 @@
 }
 
 .Footer {
+  display: flex;
+  justify-content: center;
   height: 100%;
 }
 

--- a/src/pages/MainPage.css
+++ b/src/pages/MainPage.css
@@ -3,7 +3,7 @@
   flex-direction: column;
   margin-top: 0.5rem;
   width: 95vw;
-  min-width: 280px;
+  min-width: 300px;
   color: white;
 }
 
@@ -14,6 +14,11 @@
   border: 2px solid #000000;
   box-sizing: border-box;
   border-radius: 30px;
+}
+
+.Header__title,
+.Header__subTitle {
+  line-height: 1;
 }
 
 .Header__navBar {

--- a/src/pages/MainPage.js
+++ b/src/pages/MainPage.js
@@ -1,24 +1,12 @@
 import "./MainPage.css";
+import Header from "../components/Header.js";
 import { NavLink } from "react-router-dom";
-import { ReactComponent as ProfileIcon } from "../svg/profile-fill.svg";
-import { ReactComponent as HighscoreIcon } from "../svg/chart-fill.svg";
-import { ReactComponent as OptionsIcon } from "../svg/gear-fill.svg";
 
 export default function MainPage() {
   return (
     <div className="MainPage App__gridLayout">
-      <header className="Header">
-        <div className="Header__topImage">
-          <h1>Main</h1>
-        </div>
-        <nav className="Header__navBar">
-          <ProfileIcon />
-          <NavLink to="/highscores">
-            <HighscoreIcon />
-          </NavLink>
-          <OptionsIcon />
-        </nav>
-      </header>
+      <Header title="Main" type="1" />
+
       <main>Main Page</main>
       <footer className="Footer">
         <NavLink to="/sudoku">

--- a/src/pages/SudokuPage.css
+++ b/src/pages/SudokuPage.css
@@ -4,5 +4,4 @@
   border: 2px solid #eab049;
   height: 30px;
   width: 70px;
-  margin: 0 4rem;
 }

--- a/src/pages/SudokuPage.css
+++ b/src/pages/SudokuPage.css
@@ -1,3 +1,8 @@
-.SubmitBtn {
-  margin-top: 1.5rem;
+.SubmitBtn,
+.Footer__backBtn {
+  background: #f0c350;
+  border: 2px solid #eab049;
+  height: 30px;
+  width: 70px;
+  margin: 0 4rem;
 }

--- a/src/pages/SudokuPage.js
+++ b/src/pages/SudokuPage.js
@@ -59,6 +59,7 @@ export default function SudokuPage() {
             initialSudoku={initialSudoku.current}
             currentSudoku={sudoku}
             onCellClick={handleCellClick}
+            activeCellID={selectedCell}
           />
         )}
         <NumberInputField onNumberInputClick={handleNumberInputClick} />

--- a/src/pages/SudokuPage.js
+++ b/src/pages/SudokuPage.js
@@ -3,6 +3,7 @@ import SudokuGrid from "../components/SudokuGrid/SudokuGrid.js";
 import NumberInputField from "../components/NumberInputField.js";
 import SubmitBtn from "../components/SubmitBtn.js";
 import cloneMatrix from "../utility/cloneMatrix.js";
+import { NavLink } from "react-router-dom";
 import { useEffect, useState, useRef } from "react";
 
 export default function SudokuPage() {
@@ -63,14 +64,20 @@ export default function SudokuPage() {
           />
         )}
         <NumberInputField onNumberInputClick={handleNumberInputClick} />
+
+        <h4>{sudokuStatus}</h4>
+      </main>
+      <footer className="Footer">
+        <NavLink to="/">
+          <button className="Footer__backBtn">Back</button>
+        </NavLink>
         <SubmitBtn
           value={"Submit"}
           onClick={handleSubmitClick}
           validateData={sudoku}
           url={"https://sugoku.herokuapp.com/validate"}
         />
-        <h4>{sudokuStatus}</h4>
-      </main>
+      </footer>
     </div>
   );
 }

--- a/src/pages/SudokuPage.js
+++ b/src/pages/SudokuPage.js
@@ -45,6 +45,12 @@ export default function SudokuPage() {
 
   return (
     <div className="SudokuPage App__gridLayout">
+      <header className="Header">
+        <div className="Header__topImage">
+          <h1 className="Header__title">Room01</h1>
+          <h2 className="Header__subTitle">easy</h2>
+        </div>
+      </header>
       <main className="Content">
         {isLoading || !sudoku ? (
           <p>Loading...</p>

--- a/src/pages/SudokuPage.js
+++ b/src/pages/SudokuPage.js
@@ -10,15 +10,15 @@ export default function SudokuPage() {
   let initialSudoku = useRef(Array(9).fill([]));
   const [isLoading, setIsLoading] = useState(false);
   const [sudokuStatus, setSudokuStatus] = useState("unsolved");
-  let selectedCell = [];
+  const [selectedCell, setSelectedCell] = useState([]);
 
   useEffect(() => {
-    let url = "https://sugoku.herokuapp.com/board?difficulty=easy";
+    const url = "https://sugoku.herokuapp.com/board?difficulty=easy";
     setIsLoading(true);
     fetch(url)
       .then((resp) => resp.json())
       .then((data) => {
-        setSudoku([...data.board]);
+        setSudoku(data.board);
         initialSudoku.current = cloneMatrix(data.board);
         setIsLoading(false);
       })
@@ -28,7 +28,7 @@ export default function SudokuPage() {
   }, []);
 
   function handleCellClick(cellID) {
-    selectedCell = cellID;
+    setSelectedCell(cellID);
   }
 
   function handleNumberInputClick(value) {
@@ -45,23 +45,25 @@ export default function SudokuPage() {
 
   return (
     <div className="SudokuPage App__gridLayout">
-      {isLoading || !sudoku ? (
-        <p>Loading...</p>
-      ) : (
-        <SudokuGrid
-          initialSudoku={initialSudoku.current}
-          currentSudoku={sudoku}
-          onCellClick={handleCellClick}
+      <main className="Content">
+        {isLoading || !sudoku ? (
+          <p>Loading...</p>
+        ) : (
+          <SudokuGrid
+            initialSudoku={initialSudoku.current}
+            currentSudoku={sudoku}
+            onCellClick={handleCellClick}
+          />
+        )}
+        <NumberInputField onNumberInputClick={handleNumberInputClick} />
+        <SubmitBtn
+          value={"Submit"}
+          onClick={handleSubmitClick}
+          validateData={sudoku}
+          url={"https://sugoku.herokuapp.com/validate"}
         />
-      )}
-      <NumberInputField onNumberInputClick={handleNumberInputClick} />
-      <SubmitBtn
-        value={"Submit"}
-        onClick={handleSubmitClick}
-        validateData={sudoku}
-        url={"https://sugoku.herokuapp.com/validate"}
-      />
-      <h4>{sudokuStatus}</h4>
+        <h4>{sudokuStatus}</h4>
+      </main>
     </div>
   );
 }

--- a/src/utility/getCellClassNames.js
+++ b/src/utility/getCellClassNames.js
@@ -1,0 +1,7 @@
+export default function getCellClassNames(isEditable, isSelected, cellID) {
+  const cellClassNames = `Cell ${isEditable ? "" : "Cell--locked"} ${
+    isSelected ? "Cell--active" : ""
+  } ${`CellRow${cellID[0]}`} ${`CellColumn${cellID[1]}`}`;
+
+  return cellClassNames;
+}

--- a/src/utility/isCellSelected.js
+++ b/src/utility/isCellSelected.js
@@ -1,0 +1,8 @@
+export default function isCellSelected(activeCellID, rowNumber, columnNumber) {
+  const isSelected =
+    activeCellID.length === 2 &&
+    rowNumber === activeCellID[0] &&
+    columnNumber === activeCellID[1];
+
+  return isSelected;
+}


### PR DESCRIPTION
closes #2 
closes #21 
closes #22 

What I did:
- Create isSelected prop for cells
- Add styling to Sudoku page and Sudoku grid
- Add buttons to Sudoku page
- Adjust styling for main page
- Create a header component

What still need to be done:
- Add a footer component
- Move footer and header outside of switch
- The display of the Sudoku status is temporary and will be removed  

 
